### PR TITLE
Fix promise kit dependency version number (6.7 -> 6.7.0)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
       targets: ["AwaitKit"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.7")
+    .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.7.0")
   ],
   targets: [
     .target(


### PR DESCRIPTION
Installing with SPM currently gives the following error:

```
https://github.com/yannickl/AwaitKit @ 5.1.0: error: manifest parse error(s):
Invalid version string: 6.7
```

This PR changes the version from "6.7" to "6.7.0"  so that it is compatible with SPM's config parser.