### PR TITLE
Add Guarantees Support

### DIFF
--- a/Sources/AwaitKit/AwaitKit.swift
+++ b/Sources/AwaitKit/AwaitKit.swift
@@ -63,6 +63,17 @@ public func await<T>(_ body: @escaping () throws -> T) throws -> T {
 }
 
 /**
+ Awaits that the given closure finished and returns its value or throws an error if the current and target queues are the same.
+ - parameter body: The closure that is executed on a concurrent queue.
+ - throws: when the queues are the same.
+ - returns: The value of the closure when it is done.
+ */
+@discardableResult
+public func await<T>(_ body: @escaping () -> T) throws -> T {
+  return try Queue.await.ak.await(body)
+}
+
+/**
  Awaits that the given promise resolved and returns its value or throws an error if the promise failed.
  - parameter promise: The promise to resolve.
  - throws: The error produced when the promise is rejected.
@@ -71,4 +82,15 @@ public func await<T>(_ body: @escaping () throws -> T) throws -> T {
 @discardableResult
 public func await<T>(_ promise: Promise<T>) throws -> T {
   return try Queue.await.ak.await(promise)
+}
+
+/**
+ Awaits that the given guarantee resolved and returns its value or throws an error if the current and target queues are the same.
+ - parameter guarantee: The guarantee to resolve.
+ - throws: when the queues are the same.
+ - returns: The value of the guarantee when it is resolved.
+ */
+@discardableResult
+public func await<T>(_ guarantee: Guarantee<T>) throws -> T {
+  return try Queue.await.ak.await(guarantee)
 }

--- a/Sources/AwaitKit/AwaitKit.swift
+++ b/Sources/AwaitKit/AwaitKit.swift
@@ -63,17 +63,6 @@ public func await<T>(_ body: @escaping () throws -> T) throws -> T {
 }
 
 /**
- Awaits that the given closure finished and returns its value or throws an error if the current and target queues are the same.
- - parameter body: The closure that is executed on a concurrent queue.
- - throws: when the queues are the same.
- - returns: The value of the closure when it is done.
- */
-@discardableResult
-public func await<T>(_ body: @escaping () -> T) throws -> T {
-  return try Queue.await.ak.await(body)
-}
-
-/**
  Awaits that the given promise resolved and returns its value or throws an error if the promise failed.
  - parameter promise: The promise to resolve.
  - throws: The error produced when the promise is rejected.

--- a/Sources/AwaitKit/DispatchQueue+Await.swift
+++ b/Sources/AwaitKit/DispatchQueue+Await.swift
@@ -45,21 +45,6 @@ extension Extension where Base: DispatchQueue {
   }
 
   /**
-   Awaits that the given closure finished on the receiver and returns its value or throws an error if the current and target queues are the same.
-
-   - parameter body: The closure that is executed on the receiver.
-   - throws: when the queues are the same.
-   - returns: The value of the closure when it is done.
-   - seeAlso: await(guarantee:)
-   */
-  @discardableResult
-  public final func await<T>(_ body: @escaping () -> T) throws -> T {
-    let guarantee = self.base.async(.promise, execute: body)
-
-    return try await(guarantee)
-  }
-
-  /**
    Awaits that the given promise resolved on the receiver and returns its value or throws an error if the promise failed.
 
    - parameter promise: The promise to resolve.

--- a/Tests/AwaitKitTests/AwaitKitAwaitTests.swift
+++ b/Tests/AwaitKitTests/AwaitKitAwaitTests.swift
@@ -46,6 +46,20 @@ class AwaitKitAwaitTests: XCTestCase {
     XCTAssertEqual(name, "AwaitedPromiseKit")
   }
 
+  func testSimpleAwaitGuarantee() {
+    let guarantee: Guarantee<String> = Guarantee { fulfill in
+      let deadlineTime = DispatchTime.now() + .seconds(1)
+
+      backgroundQueue.asyncAfter(deadline: deadlineTime, execute: {
+        fulfill("AwaitedPromiseKit")
+      })
+    }
+
+    let name = try! await(guarantee)
+
+    XCTAssertEqual(name, "AwaitedPromiseKit")
+  }
+
   func testSimpleFailedAwaitPromise() {
     let promise: Promise<String> = Promise { seal in
       let deadlineTime = DispatchTime.now() + .seconds(1)
@@ -64,6 +78,14 @@ class AwaitKitAwaitTests: XCTestCase {
     }
 
     XCTAssertNotNil(promise.value)
+  }
+
+  func testNoValueAwaitGuarantee() {
+    let guarantee: Guarantee<Void> = Guarantee { fulfill in
+      fulfill(())
+    }
+
+    XCTAssertNotNil(guarantee.value)
   }
 
   func testAwaitBlock() {


### PR DESCRIPTION
allow `await(guarantee)`
(currently guarantees do not work here as they are not `Promise`s)