### PR TITLE
Support awaiting optional Promises

### DIFF
--- a/Sources/AwaitKit/AwaitKit.swift
+++ b/Sources/AwaitKit/AwaitKit.swift
@@ -74,6 +74,24 @@ public func await<T>(_ promise: Promise<T>) throws -> T {
 }
 
 /**
+ If `promise` is not `nil`, awaits that the given promise resolved and returns its value or throws an error if the promise failed. If the `promise` is `nil`, immediately returns `nil`.
+
+ This function is intended to be used with optional chaining.
+
+ - parameter promise: The promise to resolve.
+ - throws: The error produced when the promise is rejected.
+ - returns: The value of the promise when it is resolved, or `nil` if the passed promise is `nil`.
+ */
+@discardableResult
+public func await<T>(_ promise: Promise<T>?) throws -> T? {
+  if let promise = promise {
+    return try Queue.await.ak.await(promise)
+  }
+
+  return nil
+}
+
+/**
  Awaits that the given guarantee resolved and returns its value or throws an error if the current and target queues are the same.
  - parameter guarantee: The guarantee to resolve.
  - throws: when the queues are the same.
@@ -82,4 +100,19 @@ public func await<T>(_ promise: Promise<T>) throws -> T {
 @discardableResult
 public func await<T>(_ guarantee: Guarantee<T>) throws -> T {
   return try Queue.await.ak.await(guarantee)
+}
+
+/**
+ If `guarantee` is not `nil`, awaits that the given guarantee resolved and returns its value or throws an error if the current and target queues are the same. If the `guarantee` is `nil`, immediately returns `nil`.
+ - parameter guarantee: The guarantee to resolve.
+ - throws: when the queues are the same.
+ - returns: The value of the guarantee when it is resolved, or `nil` if the passed guarantee is `nil`.
+ */
+@discardableResult
+public func await<T>(_ guarantee: Guarantee<T>?) throws -> T? {
+  if let guarantee = guarantee {
+    return try Queue.await.ak.await(guarantee)
+  }
+
+  return nil
 }

--- a/Tests/AwaitKitTests/AwaitKitAwaitTests.swift
+++ b/Tests/AwaitKitTests/AwaitKitAwaitTests.swift
@@ -126,4 +126,14 @@ class AwaitKitAwaitTests: XCTestCase {
 
     XCTAssertNil(error)
   }
+
+  func testAwaitNilPromise() {
+    let error = try? await(nil as Promise<Void>?)
+    XCTAssertNil(error)
+  }
+
+  func testAwaitNilGuarantee() {
+    let error = try? await(nil as Guarantee<Void>?)
+    XCTAssertNil(error)
+  }
 }


### PR DESCRIPTION
This PR adds support for `await`ing optional promises, which allows for optional chaining inside an `await` function, like so:

```swift
try await(self.foo?.bar())
```

If the promise is `nil`, `await` immediately returns `nil` and does nothing more; otherwise it executes the promise as normal and returns an `Optional` wrapping the awaited value. This is implemented for both `Promise`s and `Guarantee`s.

This should resolve #19 — please let me know what you think, and thank you for providing this library!