### PR TITLE
Support Swift 5.5 / Xcode 13

### DIFF
--- a/Sources/AwaitKit/DispatchQueue+Await.swift
+++ b/Sources/AwaitKit/DispatchQueue+Await.swift
@@ -41,7 +41,7 @@ extension Extension where Base: DispatchQueue {
   public final func await<T>(_ body: @escaping () throws -> T) throws -> T {
     let promise = self.base.async(.promise, execute: body)
 
-    return try await(promise)
+    return try `await`(promise)
   }
 
   /**


### PR DESCRIPTION
The introduction of async/await in Swift 5.5 (https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md) promoted the "await" word to keyword. Therefore to use it in this context, it must be wrapped in backticks.

Change is compatible with previous Swift versions.